### PR TITLE
chore: run Dependabot updates every Friday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,5 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
### Motivation
- Reduce Dependabot frequency from daily to a weekly cadence and run checks on Fridays to lower update noise.

### Description
- Update `schedule` in `.github/dependabot.yml` to set `interval: "weekly"` and `day: "friday"`.

### Testing
- Ran `git diff --check` and committed changes which triggered pre-commit hooks that ran `npm run lint` and `npm run format`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20af185548328807071f098224a5d)